### PR TITLE
live 11 updated scripts for python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ your preference if you know what you're doing.
     - `TSB_Y` is the vertical count which represents the number of scenes you want to control.
   - For this to work properly you must manually add or remove rows/columns for `SCENELAUNCH` and `CLIPNOTEMAP` 
   sections in [MIDI_Map.py](https://github.com/laidlaw42/Ableton-Live-MIDI-Remote-Scripts/blob/YourControllerName/YourControllerName/MIDI_Map.py).
+- If using Live 11 (sundaynightcoffee updated, PR'd and tested on 11.0.2)
+  - Use updated scripts, Ableton 11 uses Python 3 instead of Python 2, which has a few diffs in syntax. 
+  - I used python's 2to3 command to update all the scripts in this repo using 2to3 * -w within the YouControllerName directory and deleted all the .bak files. 
+  - Follow the same steps as you would for other versions, just be sure to use this 2to3'd version instead.
+  - you can also copy the MIDI_map.py between versions, you dont have to rewrite it as these are just variables that python looks at.
 
 
 ---

--- a/live11_users_use_this_folder/YourControllerName/MIDI_Map.py
+++ b/live11_users_use_this_folder/YourControllerName/MIDI_Map.py
@@ -1,0 +1,249 @@
+# Avoid using tabs for indentation, use spaces.
+# Don't use floats, they might break things.
+
+
+# Combination Mode offsets
+# ------------------------
+
+TRACK_OFFSET = -1  # offset from the left of linked session origin; set to -1 for auto-joining of multiple instances
+SCENE_OFFSET = 0  # offset from the top of linked session origin (no auto-join)
+
+# Buttons / Pads
+# -------------
+# Valid Note/CC assignments are 0 to 127, or -1 for NONE
+# Duplicate assignments are permitted
+
+BUTTONCHANNEL = 0  # Channel assignment for all mapped buttons/pads; valid range is 0 to 15 ; 0=1, 1=2 etc.
+MESSAGETYPE = 0  # Message type for buttons/pads; set to 0 for MIDI Notes, 1 for CCs.
+# When using CCs for buttons/pads, set BUTTONCHANNEL and SLIDERCHANNEL to different values.
+
+
+# Track selection box (aka that coloured box for scene/track launching)
+TSB_X = 8   # Controls the horizontal value for the track selection box. Default value is 8
+TSB_Y = 8   # Controls the horizontal value for the track selection box. Default value is 8
+
+# General
+PLAY = -1   # Global play
+STOP = -1   # Global stop
+REC = -1    # Global record
+TAPTEMPO = -1   # Tap tempo
+NUDGEUP = -1    # Tempo Nudge Up
+NUDGEDOWN = -1  # Tempo Nudge Down
+UNDO = -1   # Undo
+REDO = -1   # Redo
+LOOP = -1   # Loop on/off
+PUNCHIN = -1    # Punch in
+PUNCHOUT = -1   # Punch out
+OVERDUB = -1     # Overdub on/off
+METRONOME = -1   # Metronome on/off
+RECQUANT = -1   # Record quantization on/off
+DETAILVIEW = -1   # Detail view switch
+CLIPTRACKVIEW = -1  # Clip/Track view switch
+
+# Device Control
+DEVICELOCK = -1  # Device Lock (lock "blue hand")
+DEVICEONOFF = -1  # Device on/off
+DEVICENAVLEFT = -1  # Device nav left
+DEVICENAVRIGHT = -1  # Device nav right
+DEVICEBANKNAVLEFT = -1  # Device bank nav left
+DEVICEBANKNAVRIGHT = -1  # Device bank nav right
+DEVICEBANK = (-1,  # Bank 1 #All 8 banks must be assigned to positive values in order for bank selection to work
+              -1,  # Bank 2
+              -1,  # Bank 3
+              -1,  # Bank 4
+              -1,  # Bank 5
+              -1,  # Bank 6
+              -1,  # Bank 7
+              -1,  # Bank 8
+              )
+
+# Arrangement View Controls
+SEEKFWD = -1  # Seek forward
+SEEKRWD = -1  # Seek rewind
+
+# Session Navigation (aka "red box")
+SESSIONLEFT = -1  # Session left
+SESSIONRIGHT = -1  # Session right
+SESSIONUP = -1  # Session up
+SESSIONDOWN = -1  # Session down
+ZOOMUP = -1  # Session Zoom up
+ZOOMDOWN = -1  # Session Zoom down
+ZOOMLEFT = -1  # Session Zoom left
+ZOOMRIGHT = -1  # Session Zoom right
+
+# Track Navigation
+TRACKLEFT = -1  # Track left
+TRACKRIGHT = -1  # Track right
+
+# Scene Navigation
+SCENEUP = -1  # Scene down
+SCENEDN = -1  # Scene up
+
+# Scene Launch
+SELSCENELAUNCH = -1  # Selected scene launch
+SCENELAUNCH = (-1,  # Scene 1 Launch
+               -1,  # Scene 2
+               -1,  # Scene 3
+               -1,  # Scene 4
+               -1,  # Scene 5
+               -1,  # Scene 6
+               -1,  # Scene 7
+               -1,  # Scene 8
+               )
+
+# Clip Launch / Stop
+SELCLIPLAUNCH = -1  # Selected clip launch
+STOPALLCLIPS = -1  # Stop all clips
+
+# 8x8 Matrix note assignments
+# Track no.:     1   2   3   4   5   6   7   8
+CLIPNOTEMAP = ((-1, -1, -1, -1, -1, -1, -1, -1),  # Row 1
+               (-1, -1, -1, -1, -1, -1, -1, -1),  # Row 2
+               (-1, -1, -1, -1, -1, -1, -1, -1),  # Row 3
+               (-1, -1, -1, -1, -1, -1, -1, -1),  # Row 4
+               (-1, -1, -1, -1, -1, -1, -1, -1),  # Row 5
+               (-1, -1, -1, -1, -1, -1, -1, -1),  # Row 6
+               (-1, -1, -1, -1, -1, -1, -1, -1),  # Row 7
+               (-1, -1, -1, -1, -1, -1, -1, -1),  # Row 8
+               )
+
+# Track Control
+MASTERSEL = -1      # Master track select
+SELTRACKREC = -1    # Arm Selected Track
+SELTRACKSOLO = -1   # Solo Selected Track
+SELTRACKMUTE = -1   # Mute Selected Track
+
+TRACKSTOP = (-1,  # Track 1 Clip Stop
+             -1,  # Track 2
+             -1,  # Track 3
+             -1,  # Track 4
+             -1,  # Track 5
+             -1,  # Track 6
+             -1,  # Track 7
+             -1,  # Track 8
+             )
+
+TRACKSEL = (-1,  # Track 1 Select
+            -1,  # Track 2
+            -1,  # Track 3
+            -1,  # Track 4
+            -1,  # Track 5
+            -1,  # Track 6
+            -1,  # Track 7
+            -1,  # Track 8
+            )
+
+TRACKMUTE = (-1,  # Track 1 On/Off
+             -1,  # Track 2
+             -1,  # Track 3
+             -1,  # Track 4
+             -1,  # Track 5
+             -1,  # Track 6
+             -1,  # Track 7
+             -1,  # Track 8
+             )
+
+TRACKSOLO = (-1,  # Track 1 Solo
+             -1,  # Track 2
+             -1,  # Track 3
+             -1,  # Track 4
+             -1,  # Track 5
+             -1,  # Track 6
+             -1,  # Track 7
+             -1,  # Track 8
+             )
+
+TRACKREC = (-1,  # Track 1 Record
+            -1,  # Track 2
+            -1,  # Track 3
+            -1,  # Track 4
+            -1,  # Track 5
+            -1,  # Track 6
+            -1,  # Track 7
+            -1,  # Track 8
+            )
+
+
+# Pad Translations for Drum Rack
+PADCHANNEL = 0  # MIDI channel for Drum Rack notes
+DRUM_PADS = (-1, -1, -1, -1,  # MIDI note numbers for 4 x 4 Drum Rack
+             -1, -1, -1, -1,  # Mapping will be disabled if any notes are set to -1
+             -1, -1, -1, -1,  # Notes will be "swallowed" if already mapped elsewhere
+             -1, -1, -1, -1,
+             )
+
+
+# Sliders / Knobs
+# ---------------
+# Valid CC assignments are 0 to 127, or -1 for NONE
+# Duplicate assignments will be ignored
+SLIDERCHANNEL = 0  # Channel assignment for all mapped CCs; valid range is 0 to 15
+TEMPO_TOP = 180.0  # Upper limit of tempo control in BPM (max is 999)
+TEMPO_BOTTOM = 100.0  # Lower limit of tempo control in BPM (min is 0)
+
+TEMPOCONTROL = -1  # Tempo control CC assignment; control range is set above
+MASTERVOLUME = -1  # Master track volume
+CUELEVEL = -1  # Cue level control
+CROSSFADER = -1  # Crossfader control
+
+TRACKVOL = (-1,  # Track 1 Volume
+            -1,  # Track 2
+            -1,  # Track 3
+            -1,  # Track 4
+            -1,  # Track 5
+            -1,  # Track 6
+            -1,  # Track 7
+            -1,  # Track 8
+            )
+
+TRACKPAN = (-1,  # Track 1 Pan
+            -1,  # Track 2
+            -1,  # Track 3
+            -1,  # Track 4
+            -1,  # Track 5
+            -1,  # Track 6
+            -1,  # Track 7
+            -1,  # Track 8
+            )
+
+TRACKSENDA = (-1,  # Track 1 Send A
+              -1,  # Track 2
+              -1,  # Track 3
+              -1,  # Track 4
+              -1,  # Track 5
+              -1,  # Track 6
+              -1,  # Track 7
+              -1,  # Track 8
+              )
+
+TRACKSENDB = (-1,  # Track 1 Send B
+              -1,  # Track 2
+              -1,  # Track 3
+              -1,  # Track 4
+              -1,  # Track 5
+              -1,  # Track 6
+              -1,  # Track 7
+              -1,  # Track 8
+              )
+
+TRACKSENDC = (-1,  # Track 1 Send C
+              -1,  # Track 2
+              -1,  # Track 3
+              -1,  # Track 4
+              -1,  # Track 5
+              -1,  # Track 6
+              -1,  # Track 7
+              -1,  # Track 8
+              )
+
+PARAMCONTROL = (-1,  # Param 1 #All 8 params must be assigned to positive values in order for param control to work
+                -1,  # Param 2
+                -1,  # Param 3
+                -1,  # Param 4
+                -1,  # Param 5
+                -1,  # Param 6
+                -1,  # Param 7
+                -1,  # Param 8
+                )
+
+

--- a/live11_users_use_this_folder/YourControllerName/SpecialChannelStripComponent.py
+++ b/live11_users_use_this_folder/YourControllerName/SpecialChannelStripComponent.py
@@ -1,0 +1,39 @@
+# emacs-mode: -*- python-*-
+# -*- coding: utf-8 -*-
+
+from _Framework.ChannelStripComponent import ChannelStripComponent
+TRACK_FOLD_DELAY = 5
+
+
+class SpecialChannelStripComponent(ChannelStripComponent):
+    """ Subclass of channel strip component using select button for (un)folding tracks """
+    __module__ = __name__
+
+    def __init__(self):
+        ChannelStripComponent.__init__(self)
+        self._toggle_fold_ticks_delay = -1
+        self._register_timer_callback(self._on_timer)
+
+    def disconnect(self):
+        self._unregister_timer_callback(self._on_timer)
+        ChannelStripComponent.disconnect(self)
+
+    def _select_value(self, value):
+        ChannelStripComponent._select_value(self, value)
+        if (self.is_enabled() and (self._track != None)):
+            if (self._track.is_foldable and (self._select_button.is_momentary() and (value != 0))):
+                self._toggle_fold_ticks_delay = TRACK_FOLD_DELAY
+            else:
+                self._toggle_fold_ticks_delay = -1
+
+    def _on_timer(self):
+        if (self.is_enabled() and (self._track != None)):
+            if (self._toggle_fold_ticks_delay > -1):
+                assert self._track.is_foldable
+                if (self._toggle_fold_ticks_delay == 0):
+                    self._track.fold_state = (not self._track.fold_state)
+                self._toggle_fold_ticks_delay -= 1
+
+
+# local variables:
+# tab-width: 4

--- a/live11_users_use_this_folder/YourControllerName/SpecialMixerComponent.py
+++ b/live11_users_use_this_folder/YourControllerName/SpecialMixerComponent.py
@@ -1,0 +1,17 @@
+from _Framework.MixerComponent import MixerComponent
+from .SpecialChannelStripComponent import SpecialChannelStripComponent
+
+
+class SpecialMixerComponent(MixerComponent):
+    """ Special mixer class that uses return tracks alongside midi and audio tracks """
+    __module__ = __name__
+
+    def __init__(self, num_tracks):
+        MixerComponent.__init__(self, num_tracks)
+
+    def tracks_to_use(self):
+        return tuple(self.song().visible_tracks) + tuple(self.song().return_tracks)
+
+    def _create_strip(self):
+        return SpecialChannelStripComponent()
+

--- a/live11_users_use_this_folder/YourControllerName/SpecialSessionComponent.py
+++ b/live11_users_use_this_folder/YourControllerName/SpecialSessionComponent.py
@@ -1,0 +1,55 @@
+# emacs-mode: -*- python-*-
+# -*- coding: utf-8 -*-
+
+import Live
+from _Framework.SessionComponent import SessionComponent
+from _Framework.ButtonElement import ButtonElement
+class SpecialSessionComponent(SessionComponent):
+    " Special SessionComponent for APC combination mode and button to fire selected clip slot "
+    __module__ = __name__
+
+    def __init__(self, num_tracks, num_scenes):
+        SessionComponent.__init__(self, num_tracks, num_scenes)
+        self._slot_launch_button = None
+
+    def disconnect(self):
+        SessionComponent.disconnect(self)
+        if (self._slot_launch_button != None):
+            self._slot_launch_button.remove_value_listener(self._slot_launch_value)
+            self._slot_launch_button = None
+
+    def link_with_track_offset(self, track_offset, scene_offset):
+        assert (track_offset >= 0)
+        assert (scene_offset >= 0)
+        if self._is_linked():
+            self._unlink()
+        self.set_offsets(track_offset, scene_offset)
+        self._link()
+
+    def unlink(self):
+        if self._is_linked():
+            self._unlink()
+
+    def set_slot_launch_button(self, button):
+        assert ((button == None) or isinstance(button, ButtonElement))
+        if (self._slot_launch_button != button):
+            if (self._slot_launch_button != None):
+                self._slot_launch_button.remove_value_listener(self._slot_launch_value)
+            self._slot_launch_button = button
+            if (self._slot_launch_button != None):
+                self._slot_launch_button.add_value_listener(self._slot_launch_value)
+
+            self.update()
+
+    def _slot_launch_value(self, value):
+        assert (value in range(128))
+        assert (self._slot_launch_button != None)
+        if self.is_enabled():
+            if ((value != 0) or (not self._slot_launch_button.is_momentary())):
+                if (self.song().view.highlighted_clip_slot != None):
+                    self.song().view.highlighted_clip_slot.fire()
+
+
+
+# local variables:
+# tab-width: 4

--- a/live11_users_use_this_folder/YourControllerName/SpecialTransportComponent.py
+++ b/live11_users_use_this_folder/YourControllerName/SpecialTransportComponent.py
@@ -1,0 +1,273 @@
+# There are lot of things to explore that you can use to add extra functionality to your scipt.
+# You'd essentially enable it here by uncommenting then add it YourControllerName.py and MIDI_Map.
+# I experiment more and add myself in the future.
+
+import Live
+from _Framework.TransportComponent import TransportComponent
+from _Framework.ButtonElement import ButtonElement
+from _Framework.EncoderElement import EncoderElement #added
+from _Framework.SubjectSlot import subject_slot #added
+#TEMPO_TOP = 300.0
+#TEMPO_BOTTOM = 40.0
+from .MIDI_Map import TEMPO_TOP
+from .MIDI_Map import TEMPO_BOTTOM
+class SpecialTransportComponent(TransportComponent):
+    __doc__ = ' TransportComponent that only uses certain buttons if a shift button is pressed '
+    def __init__(self):
+        TransportComponent.__init__(self)
+        #self._shift_button = None
+        self._quant_toggle_button = None
+        #self._shift_pressed = False
+        self._last_quant_value = Live.Song.RecordingQuantization.rec_q_eight
+        self.song().add_midi_recording_quantization_listener(self._on_quantisation_changed)
+        self._on_quantisation_changed()
+        self._undo_button = None #added from OpenLabs SpecialTransportComponent script
+        self._redo_button = None #added from OpenLabs SpecialTransportComponent script
+        #self._bts_button = None #added from OpenLabs SpecialTransportComponent script
+        self._tempo_encoder_control = None #new addition
+        return None
+
+    def disconnect(self):
+        TransportComponent.disconnect(self)
+        #if self._shift_button != None:
+            #self._shift_button.remove_value_listener(self._shift_value)
+            #self._shift_button = None
+        if self._quant_toggle_button != None:
+            self._quant_toggle_button.remove_value_listener(self._quant_toggle_value)
+            self._quant_toggle_button = None
+        self.song().remove_midi_recording_quantization_listener(self._on_quantisation_changed)
+        if (self._undo_button != None): #added from OpenLabs SpecialTransportComponent script
+            self._undo_button.remove_value_listener(self._undo_value)
+            self._undo_button = None
+        if (self._redo_button != None): #added from OpenLabs SpecialTransportComponent script
+            self._redo_button.remove_value_listener(self._redo_value)
+            self._redo_button = None
+        #if (self._bts_button != None): #added from OpenLabs SpecialTransportComponent script
+            #self._bts_button.remove_value_listener(self._bts_value)
+            #self._bts_button = None
+        if (self._tempo_encoder_control != None): #new addition
+            self._tempo_encoder_control.remove_value_listener(self._tempo_encoder_value)
+            self._tempo_encoder_control = None
+        return None
+
+    #def set_shift_button(self, button):
+        #if not(button == None or isinstance(button, ButtonElement) and button.is_momentary()):
+            #isinstance(button, ButtonElement)
+            #raise AssertionError
+        #if self._shift_button != button:
+            #if self._shift_button != None:
+                #self._shift_button.remove_value_listener(self._shift_value)
+            #self._shift_button = button
+            #if self._shift_button != None:
+                #self._shift_button.add_value_listener(self._shift_value)
+            #
+            #self.update()
+        #return None
+
+    def set_quant_toggle_button(self, button):
+        if not(button == None or isinstance(button, ButtonElement) and button.is_momentary()):
+            isinstance(button, ButtonElement)
+            raise AssertionError
+        if self._quant_toggle_button != button:
+            if self._quant_toggle_button != None:
+                self._quant_toggle_button.remove_value_listener(self._quant_toggle_value)
+            self._quant_toggle_button = button
+            if self._quant_toggle_button != None:
+                self._quant_toggle_button.add_value_listener(self._quant_toggle_value)
+
+            self.update()
+        return None
+
+    #def update(self):
+        #self._on_metronome_changed()
+        #self._on_overdub_changed()
+        #self._on_quantisation_changed()
+        #self._on_nudge_up_changed() #added
+        #self._on_nudge_down_changed #added
+
+    #def _shift_value(self, value):
+        #if not self._shift_button != None:
+            #raise AssertionError
+        #if not value in range(128):
+            #raise AssertionError
+        #self._shift_pressed = value != 0
+        #if self.is_enabled():
+            #self.is_enabled()
+            #self.update()
+        #else:
+            #self.is_enabled()
+        #return None
+
+    #def _metronome_value(self, value):
+        #if not self._shift_pressed:
+        ###if self._shift_pressed:
+            #TransportComponent._metronome_value(self, value)
+
+
+    #def _overdub_value(self, value):
+        #if not self._shift_pressed:
+            #TransportComponent._overdub_value(self, value)
+
+
+    #def _nudge_up_value(self, value): #added
+        #if not self._shift_pressed:
+            #TransportComponent._nudge_up_value(self, value)
+
+
+    #def _nudge_down_value(self, value): #added
+        #if not self._shift_pressed:
+            #TransportComponent._nudge_down_value(self, value)
+
+
+    #def _tap_tempo_value(self, value): # Added as Shift + Tap Tempo
+        #if not self._shift_pressed:
+        ##if self._shift_pressed:
+            #TransportComponent._tap_tempo_value(self, value)
+
+
+    def _quant_toggle_value(self, value):
+        assert (self._quant_toggle_button != None)
+        assert (value in range(128))
+        assert (self._last_quant_value != Live.Song.RecordingQuantization.rec_q_no_q)
+        if self.is_enabled(): # and (not self._shift_pressed):
+            if ((value != 0) or (not self._quant_toggle_button.is_momentary())):
+                quant_value = self.song().midi_recording_quantization
+                if (quant_value != Live.Song.RecordingQuantization.rec_q_no_q):
+                    self._last_quant_value = quant_value
+                    self.song().midi_recording_quantization = Live.Song.RecordingQuantization.rec_q_no_q
+                else:
+                    self.song().midi_recording_quantization = self._last_quant_value
+
+
+    #def _on_metronome_changed(self):
+        #if not self._shift_pressed:
+        ##if self._shift_pressed:
+            #TransportComponent._on_metronome_changed(self)
+
+
+    #def _on_overdub_changed(self):
+        #if not self._shift_pressed:
+            #TransportComponent._on_overdub_changed(self)
+
+
+    #def _on_nudge_up_changed(self): #added
+        #if not self._shift_pressed:
+            #TransportComponent._on_nudge_up_changed(self)
+
+
+    #def _on_nudge_down_changed(self): #added
+        #if not self._shift_pressed:
+            #TransportComponent._on_nudge_down_changed(self)
+
+
+    def _on_quantisation_changed(self):
+        if self.is_enabled():
+            quant_value = self.song().midi_recording_quantization
+            quant_on = (quant_value != Live.Song.RecordingQuantization.rec_q_no_q)
+            if quant_on:
+                self._last_quant_value = quant_value
+            if self._quant_toggle_button != None: #((not self._shift_pressed) and (self._quant_toggle_button != None)):
+                if quant_on:
+                    self._quant_toggle_button.turn_on()
+                else:
+                    self._quant_toggle_button.turn_off()
+
+    """ from OpenLabs module SpecialTransportComponent """
+
+    def set_undo_button(self, undo_button):
+        assert isinstance(undo_button, (ButtonElement,
+                                        type(None)))
+        if (undo_button != self._undo_button):
+            if (self._undo_button != None):
+                self._undo_button.remove_value_listener(self._undo_value)
+            self._undo_button = undo_button
+            if (self._undo_button != None):
+                self._undo_button.add_value_listener(self._undo_value)
+            self.update()
+
+
+
+    def set_redo_button(self, redo_button):
+        assert isinstance(redo_button, (ButtonElement,
+                                        type(None)))
+        if (redo_button != self._redo_button):
+            if (self._redo_button != None):
+                self._redo_button.remove_value_listener(self._redo_value)
+            self._redo_button = redo_button
+            if (self._redo_button != None):
+                self._redo_button.add_value_listener(self._redo_value)
+            self.update()
+
+
+    #def set_bts_button(self, bts_button): #"back to start" button
+        #assert isinstance(bts_button, (ButtonElement,
+                                       #type(None)))
+        #if (bts_button != self._bts_button):
+            #if (self._bts_button != None):
+                #self._bts_button.remove_value_listener(self._bts_value)
+            #self._bts_button = bts_button
+            #if (self._bts_button != None):
+                #self._bts_button.add_value_listener(self._bts_value)
+            #self.update()
+
+
+    def _undo_value(self, value):
+        #if self._shift_pressed: #added
+        assert (self._undo_button != None)
+        assert (value in range(128))
+        if self.is_enabled():
+            if ((value != 0) or (not self._undo_button.is_momentary())):
+                if self.song().can_undo:
+                    self.song().undo()
+
+
+    def _redo_value(self, value):
+        #if self._shift_pressed: #added
+        assert (self._redo_button != None)
+        assert (value in range(128))
+        if self.is_enabled():
+            if ((value != 0) or (not self._redo_button.is_momentary())):
+                if self.song().can_redo:
+                    self.song().redo()
+
+
+    #def _bts_value(self, value):
+        #assert (self._bts_button != None)
+        #assert (value in range(128))
+        #if self.is_enabled():
+            #if ((value != 0) or (not self._bts_button.is_momentary())):
+                #self.song().current_song_time = 0.0
+
+
+    def _tempo_encoder_value(self, value):
+        ##if not self._shift_pressed:
+        #if self._shift_pressed:
+        assert (self._tempo_encoder_control != None)
+        assert (value in range(128))
+        backwards = (value >= 64)
+        step = 0.1 #step = 1.0 #reduce this for finer control; 1.0 is 1 bpm
+        if backwards:
+            amount = (value - 128)
+        else:
+            amount = value
+        tempo = max(20, min(999, (self.song().tempo + (amount * step))))
+        self.song().tempo = tempo
+
+
+    def set_tempo_encoder(self, control):
+        assert ((control == None) or (isinstance(control, EncoderElement) and (control.message_map_mode() is Live.MidiMap.MapMode.relative_two_compliment)))
+        if (self._tempo_encoder_control != None):
+            self._tempo_encoder_control.remove_value_listener(self._tempo_encoder_value)
+        self._tempo_encoder_control = control
+        if (self._tempo_encoder_control != None):
+            self._tempo_encoder_control.add_value_listener(self._tempo_encoder_value)
+        self.update()
+
+    @subject_slot('value')
+    def _tempo_value(self, value): #Override to pull tempo range from MIDI_Maps.py
+        assert (self._tempo_control != None)
+        assert (value in range(128))
+        if self.is_enabled():
+            fraction = ((TEMPO_TOP - TEMPO_BOTTOM) / 127.0)
+            self.song().tempo = ((fraction * value) + TEMPO_BOTTOM)
+

--- a/live11_users_use_this_folder/YourControllerName/SpecialViewControllerComponent.py
+++ b/live11_users_use_this_folder/YourControllerName/SpecialViewControllerComponent.py
@@ -1,0 +1,220 @@
+# There are lot of things to explore that you can use to add extra functionality to your scipt.
+# You'd essentially enable it here by uncommenting then add it YourControllerName.py and MIDI_Map.
+# I experiment more and add myself in the future.
+
+# Partial --== Decompile ==-- with fixes
+import Live
+from _Framework.ControlSurfaceComponent import ControlSurfaceComponent
+from _Framework.ButtonElement import ButtonElement
+SHOW_PLAYING_CLIP_DELAY = 5
+class DetailViewControllerComponent(ControlSurfaceComponent):
+    __module__ = __name__
+    __doc__ = ' Component that can toggle the device chain- and clip view of the selected track '
+
+    def __init__(self):
+        ControlSurfaceComponent.__init__(self)
+        self._device_clip_toggle_button = None
+        self._detail_toggle_button = None
+        self._left_button = None
+        self._right_button = None
+        #self._shift_button = None
+        #self._shift_pressed = False
+        self._show_playing_clip_ticks_delay = -1
+        self.application().view.add_is_view_visible_listener('Detail', self._detail_view_visibility_changed)
+        self._register_timer_callback(self._on_timer)
+        return None
+
+    def disconnect(self):
+        self._unregister_timer_callback(self._on_timer)
+        self.application().view.remove_is_view_visible_listener('Detail', self._detail_view_visibility_changed)
+        if self._device_clip_toggle_button != None:
+            self._device_clip_toggle_button.remove_value_listener(self._device_clip_toggle_value)
+            self._device_clip_toggle_button = None
+        if self._detail_toggle_button != None:
+            self._detail_toggle_button.remove_value_listener(self._detail_toggle_value)
+            self._detail_toggle_button = None
+        if self._left_button != None:
+            self._left_button.remove_value_listener(self._nav_value)
+            self._left_button = None
+        if self._right_button != None:
+            self._right_button.remove_value_listener(self._nav_value)
+            self._right_button = None
+        #if self._shift_button != None:
+            #self._shift_button.remove_value_listener(self._shift_value)
+            #self._shift_button = None
+        return None
+
+    def set_device_clip_toggle_button(self, button):
+        if not(button == None or isinstance(button, ButtonElement)):
+            isinstance(button, ButtonElement)
+            raise AssertionError
+        if self._device_clip_toggle_button != button:
+            if self._device_clip_toggle_button != None:
+                self._device_clip_toggle_button.remove_value_listener(self._device_clip_toggle_value)
+            self._device_clip_toggle_button = button
+            if self._device_clip_toggle_button != None:
+                self._device_clip_toggle_button.add_value_listener(self._device_clip_toggle_value)
+
+            self.update()
+        return None
+
+    def set_detail_toggle_button(self, button):
+        if not(button == None or isinstance(button, ButtonElement)):
+            isinstance(button, ButtonElement)
+            raise AssertionError
+        if self._detail_toggle_button != button:
+            if self._detail_toggle_button != None:
+                self._detail_toggle_button.remove_value_listener(self._detail_toggle_value)
+            self._detail_toggle_button = button
+            if self._detail_toggle_button != None:
+                self._detail_toggle_button.add_value_listener(self._detail_toggle_value)
+
+            self.update()
+        return None
+
+    def set_device_nav_buttons(self, left_button, right_button):
+        if not(left_button == None or isinstance(left_button, ButtonElement)):
+            isinstance(left_button, ButtonElement)
+            raise AssertionError
+        if not(right_button == None or isinstance(right_button, ButtonElement)):
+            isinstance(right_button, ButtonElement)
+            raise AssertionError
+        identify_sender = True
+        if self._left_button != None:
+            self._left_button.remove_value_listener(self._nav_value)
+        self._left_button = left_button
+        if self._left_button != None:
+            self._left_button.add_value_listener(self._nav_value, identify_sender)
+        if self._right_button != None:
+            self._right_button.remove_value_listener(self._nav_value)
+        self._right_button = right_button
+        if self._right_button != None:
+            self._right_button.add_value_listener(self._nav_value, identify_sender)
+
+        self.update()
+        return None
+
+    #def set_shift_button(self, button):
+        #if not(button == None or isinstance(button, ButtonElement) and button.is_momentary()):
+            #isinstance(button, ButtonElement)
+            #raise AssertionError
+        #if self._shift_button != button:
+            #if self._shift_button != None:
+                #self._shift_button.remove_value_listener(self._shift_value)
+            #self._shift_button = button
+            #if self._shift_button != None:
+                #self._shift_button.add_value_listener(self._shift_value)
+            #
+            #self.update()
+        #return None
+
+    def on_enabled_changed(self):
+        self.update()
+
+    def update(self):
+        pass
+        #if self.is_enabled():
+            #self.is_enabled()
+            #if not self._shift_pressed:
+                #self._shift_pressed
+                #if self._left_button != None:
+                    #self._left_button.turn_off()
+                #if self._right_button != None:
+                    #self._right_button.turn_off()
+                #if self._device_clip_toggle_button != None:
+                    #self._device_clip_toggle_button.turn_off()
+                #self._detail_view_visibility_changed()
+            #else:
+                #self._shift_pressed
+        #else:
+            #self.is_enabled()
+        return None
+
+    def _detail_view_visibility_changed(self):
+        if self.is_enabled() and self._detail_toggle_button != None: #not self._shift_pressed and self._detail_toggle_button != None:
+            if self.application().view.is_view_visible('Detail'):
+                self.application().view.is_view_visible('Detail')
+                self._detail_toggle_button.turn_on()
+            else:
+                self.application().view.is_view_visible('Detail')
+                self._detail_toggle_button.turn_off()
+        else:
+            self.is_enabled()
+        return None
+
+    def _device_clip_toggle_value(self, value):
+        if not self._device_clip_toggle_button != None:
+            raise AssertionError
+        if not value in range(128):
+            raise AssertionError
+        if self.is_enabled(): #and not self._shift_pressed:
+            button_is_momentary = self._device_clip_toggle_button.is_momentary()
+            if not button_is_momentary or value != 0:
+                not button_is_momentary
+                if not self.application().view.is_view_visible('Detail'):
+                    self.application().view.is_view_visible('Detail')
+                    self.application().view.show_view('Detail')
+                else:
+                    self.application().view.is_view_visible('Detail')
+                if not self.application().view.is_view_visible('Detail/DeviceChain'):
+                    self.application().view.is_view_visible('Detail/DeviceChain')
+                    self.application().view.show_view('Detail/DeviceChain')
+                else:
+                    self.application().view.is_view_visible('Detail/DeviceChain')
+                    self.application().view.show_view('Detail/Clip')
+            if button_is_momentary and value != 0:
+                self._show_playing_clip_ticks_delay = SHOW_PLAYING_CLIP_DELAY
+            else:
+                button_is_momentary
+                self._show_playing_clip_ticks_delay = -1
+        else:
+            self.is_enabled()
+        return None
+
+
+    def _detail_toggle_value(self, value):
+        assert (self._detail_toggle_button != None)
+        assert (value in range(128))
+        if self.is_enabled(): # and (not self._shift_pressed):
+            if ((not self._detail_toggle_button.is_momentary()) or (value != 0)):
+                if (not self.application().view.is_view_visible('Detail')):
+                    self.application().view.show_view('Detail')
+                else:
+                    self.application().view.hide_view('Detail')
+
+
+    #def _shift_value(self, value):
+        #if not self._shift_button != None:
+            #raise AssertionError
+        #if not value in range(128):
+            #raise AssertionError
+        #self._shift_pressed = value != 0
+        #self.update()
+        #return None
+
+    def _nav_value(self, value, sender):
+        assert ((sender != None) and (sender in (self._left_button,
+                                                 self._right_button)))
+        if self.is_enabled(): # and (not self._shift_pressed):
+            if ((not sender.is_momentary()) or (value != 0)):
+                modifier_pressed = True
+                if ((not self.application().view.is_view_visible('Detail')) or (not self.application().view.is_view_visible('Detail/DeviceChain'))):
+                    self.application().view.show_view('Detail')
+                    self.application().view.show_view('Detail/DeviceChain')
+                else:
+                    direction = Live.Application.Application.View.NavDirection.left
+                    if (sender == self._right_button):
+                        direction = Live.Application.Application.View.NavDirection.right
+                    self.application().view.scroll_view(direction, 'Detail/DeviceChain', (not modifier_pressed))
+
+    def _on_timer(self):
+        if self.is_enabled(): # and (not self._shift_pressed):
+            if (self._show_playing_clip_ticks_delay > -1):
+                if (self._show_playing_clip_ticks_delay == 0):
+                    song = self.song()
+                    playing_slot_index = song.view.selected_track.playing_slot_index
+                    if (playing_slot_index > -1):
+                        song.view.selected_scene = song.scenes[playing_slot_index]
+                        if song.view.highlighted_clip_slot.has_clip:
+                            self.application().view.show_view('Detail/Clip')
+                self._show_playing_clip_ticks_delay -= 1

--- a/live11_users_use_this_folder/YourControllerName/SpecialZoomingComponent.py
+++ b/live11_users_use_this_folder/YourControllerName/SpecialZoomingComponent.py
@@ -1,0 +1,56 @@
+# emacs-mode: -*- python-*-
+# -*- coding: utf-8 -*-
+
+import Live
+from _Framework.SessionZoomingComponent import SessionZoomingComponent
+from _Framework.ButtonElement import ButtonElement
+class SpecialZoomingComponent(SessionZoomingComponent):
+    ' Special ZoomingComponent that uses clip stop buttons for stop all when zoomed '
+    __module__ = __name__
+
+    def __init__(self, session):
+        SessionZoomingComponent.__init__(self, session)
+
+
+    def _scroll_up(self):
+        #if self._is_zoomed_out:
+        height       = self._session.height()
+        track_offset = self._session.track_offset()
+        scene_offset = self._session.scene_offset()
+
+        if scene_offset > 0:
+            new_scene_offset = scene_offset
+            if scene_offset % height > 0:
+                new_scene_offset -= (scene_offset % height)
+            else:
+                new_scene_offset = max(0, scene_offset - height)
+            self._session.set_offsets(track_offset, new_scene_offset)
+
+    def _scroll_down(self):
+        #if self._is_zoomed_out:
+            height       = self._session.height()
+            track_offset = self._session.track_offset()
+            scene_offset = self._session.scene_offset()
+            new_scene_offset = scene_offset + height - (scene_offset % height)
+            self._session.set_offsets(track_offset, new_scene_offset)
+
+    def _scroll_left(self):
+        #if self._is_zoomed_out:
+        width        = self._session.width()
+        track_offset = self._session.track_offset()
+        scene_offset = self._session.scene_offset()
+        if track_offset > 0:
+            new_track_offset = track_offset
+            if track_offset % width > 0:
+                new_track_offset -= (track_offset % width)
+            else:
+                new_track_offset = max(0, track_offset - width)
+            self._session.set_offsets(new_track_offset, scene_offset)
+
+    def _scroll_right(self):
+        #if self._is_zoomed_out:
+        width        = self._session.width()
+        track_offset = self._session.track_offset()
+        scene_offset = self._session.scene_offset()
+        new_track_offset = track_offset + width - (track_offset % width)
+        self._session.set_offsets(new_track_offset, scene_offset)

--- a/live11_users_use_this_folder/YourControllerName/YourControllerName.py
+++ b/live11_users_use_this_folder/YourControllerName/YourControllerName.py
@@ -1,0 +1,224 @@
+
+
+import Live
+from _Framework.ControlSurface import ControlSurface
+from _Framework.InputControlElement import *
+from _Framework.SliderElement import SliderElement
+from _Framework.ButtonElement import ButtonElement
+from _Framework.ButtonMatrixElement import ButtonMatrixElement
+from _Framework.ChannelStripComponent import ChannelStripComponent
+from _Framework.DeviceComponent import DeviceComponent
+from _Framework.ControlSurfaceComponent import ControlSurfaceComponent
+from _Framework.SessionZoomingComponent import SessionZoomingComponent
+from .SpecialMixerComponent import SpecialMixerComponent
+from .SpecialTransportComponent import SpecialTransportComponent
+from .SpecialSessionComponent import SpecialSessionComponent
+from .SpecialZoomingComponent import SpecialZoomingComponent
+from .SpecialViewControllerComponent import DetailViewControllerComponent
+from .MIDI_Map import *
+
+
+# MIDI_NOTE_TYPE = 0
+# MIDI_CC_TYPE = 1
+# MIDI_PB_TYPE = 2
+
+
+class YourControllerName(ControlSurface):   # Make sure you update the name
+    __doc__ = " Script for YourControllerName in APC emulation mode "   # Make sure you update the name
+
+    _active_instances = []
+
+    def _combine_active_instances():
+        track_offset = 0
+        scene_offset = 0
+        for instance in YourControllerName._active_instances:   # Make sure you update the name
+            instance._activate_combination_mode(track_offset, scene_offset)
+            track_offset += instance._session.width()
+    _combine_active_instances = staticmethod(_combine_active_instances)
+
+    def __init__(self, c_instance):
+        ControlSurface.__init__(self, c_instance)
+        # self.set_suppress_rebuild_requests(True)
+        with self.component_guard():
+            self._note_map = []
+            self._ctrl_map = []
+            self._load_MIDI_map()
+            self._session = None
+            self._session_zoom = None
+            self._mixer = None
+            self._setup_session_control()
+            self._setup_mixer_control()
+            self._session.set_mixer(self._mixer)
+            self._setup_device_and_transport_control()
+            self.set_highlighting_session_component(self._session)
+            # self.set_suppress_rebuild_requests(False)
+        self._pads = []
+        self._load_pad_translations()
+        self._do_combine()
+
+    def disconnect(self):
+        self._note_map = None
+        self._ctrl_map = None
+        self._pads = None
+        self._do_uncombine()
+        self._shift_button = None
+        self._session = None
+        self._session_zoom = None
+        self._mixer = None
+        ControlSurface.disconnect(self)
+
+    def _do_combine(self):
+        if self not in YourControllerName._active_instances:    # Make sure you update the name
+            YourControllerName._active_instances.append(self)   # Make sure you update the name
+            YourControllerName._combine_active_instances()  # Make sure you update the name
+
+    def _do_uncombine(self):
+        if (self in YourControllerName._active_instances) and YourControllerName._active_instances.remove(self):    # Make sure you update the name
+            self._session.unlink()
+            YourControllerName._combine_active_instances()  # Make sure you update the name
+
+    def _activate_combination_mode(self, track_offset, scene_offset):
+        if TRACK_OFFSET != -1:
+            track_offset = TRACK_OFFSET
+        if SCENE_OFFSET != -1:
+            scene_offset = SCENE_OFFSET
+        self._session.link_with_track_offset(track_offset, scene_offset)
+
+    def _setup_session_control(self):
+        is_momentary = True
+        self._session = SpecialSessionComponent(TSB_X, TSB_Y)   # Track selection box size (X,Y) (horizontal, vertical).
+        self._session.name = 'Session_Control'
+        self._session.set_track_bank_buttons(self._note_map[SESSIONRIGHT], self._note_map[SESSIONLEFT])
+        self._session.set_scene_bank_buttons(self._note_map[SESSIONDOWN], self._note_map[SESSIONUP])
+        self._session.set_select_buttons(self._note_map[SCENEDN], self._note_map[SCENEUP])
+        # range(tsb_x) is the horizontal count for the track selection box
+        self._scene_launch_buttons = [self._note_map[SCENELAUNCH[index]] for index in range(TSB_X)]
+        # range(tsb_y) Range value is the track selection
+        self._track_stop_buttons = [self._note_map[TRACKSTOP[index]] for index in range(TSB_Y)]
+        self._session.set_stop_all_clips_button(self._note_map[STOPALLCLIPS])
+        self._session.set_stop_track_clip_buttons(tuple(self._track_stop_buttons))
+        self._session.selected_scene().name = 'Selected_Scene'
+        self._session.selected_scene().set_launch_button(self._note_map[SELSCENELAUNCH])
+        self._session.set_slot_launch_button(self._note_map[SELCLIPLAUNCH])
+        for scene_index in range(TSB_Y):    # Change range() value to set the vertical count for track selection box
+            scene = self._session.scene(scene_index)
+            scene.name = 'Scene_' + str(scene_index)
+            button_row = []
+            scene.set_launch_button(self._scene_launch_buttons[scene_index])
+            scene.set_triggered_value(2)
+            for track_index in range(TSB_X):    # Change range() value to set the horizontal count for track selection box
+                button = self._note_map[CLIPNOTEMAP[scene_index][track_index]]
+                button_row.append(button)
+                clip_slot = scene.clip_slot(track_index)
+                clip_slot.name = str(track_index) + '_Clip_Slot_' + str(scene_index)
+                clip_slot.set_launch_button(button)
+        self._session_zoom = SpecialZoomingComponent(self._session)
+        self._session_zoom.name = 'Session_Overview'
+        self._session_zoom.set_nav_buttons(self._note_map[ZOOMUP], self._note_map[ZOOMDOWN], self._note_map[ZOOMLEFT], self._note_map[ZOOMRIGHT])
+
+    def _setup_mixer_control(self):
+
+        is_momentary = True
+        self._mixer = SpecialMixerComponent(8)
+        self._mixer.name = 'Mixer'
+        self._mixer.master_strip().name = 'Master_Channel_Strip'
+        self._mixer.master_strip().set_select_button(self._note_map[MASTERSEL])
+        self._mixer.selected_strip().name = 'Selected_Channel_Strip'
+        self._mixer.set_select_buttons(self._note_map[TRACKRIGHT], self._note_map[TRACKLEFT])
+        self._mixer.set_crossfader_control(self._ctrl_map[CROSSFADER])
+        self._mixer.set_prehear_volume_control(self._ctrl_map[CUELEVEL])
+        self._mixer.master_strip().set_volume_control(self._ctrl_map[MASTERVOLUME])
+        self._mixer.selected_strip().set_arm_button(self._note_map[SELTRACKREC])
+        self._mixer.selected_strip().set_solo_button(self._note_map[SELTRACKSOLO])
+        self._mixer.selected_strip().set_mute_button(self._note_map[SELTRACKMUTE])
+        for track in range(8):
+            # My guess is that altering the range here will allow you to alter the range of mixer tracks
+            # So if you had a 16 fader mixer, this would come in handy.
+            strip = self._mixer.channel_strip(track)
+            strip.name = 'Channel_Strip_' + str(track)
+            strip.set_arm_button(self._note_map[TRACKREC[track]])
+            strip.set_solo_button(self._note_map[TRACKSOLO[track]])
+            strip.set_mute_button(self._note_map[TRACKMUTE[track]])
+            strip.set_select_button(self._note_map[TRACKSEL[track]])
+            strip.set_volume_control(self._ctrl_map[TRACKVOL[track]])
+            strip.set_pan_control(self._ctrl_map[TRACKPAN[track]])
+            strip.set_send_controls((self._ctrl_map[TRACKSENDA[track]], self._ctrl_map[TRACKSENDB[track]], self._ctrl_map[TRACKSENDC[track]]))
+            strip.set_invert_mute_feedback(True)
+
+    def _setup_device_and_transport_control(self):
+        is_momentary = True
+        self._device = DeviceComponent()
+        self._device.name = 'Device_Component'
+        device_bank_buttons = []
+        device_param_controls = []
+        for index in range(8):
+            device_param_controls.append(self._ctrl_map[PARAMCONTROL[index]])
+            device_bank_buttons.append(self._note_map[DEVICEBANK[index]])
+        if None not in device_bank_buttons:
+            self._device.set_bank_buttons(tuple(device_bank_buttons))
+        if None not in device_param_controls:
+            self._device.set_parameter_controls(tuple(device_param_controls))
+        self._device.set_on_off_button(self._note_map[DEVICEONOFF])
+        self._device.set_bank_nav_buttons(self._note_map[DEVICEBANKNAVLEFT], self._note_map[DEVICEBANKNAVRIGHT])
+        self._device.set_lock_button(self._note_map[DEVICELOCK])
+        self.set_device_component(self._device)
+
+        detail_view_toggler = DetailViewControllerComponent()
+        detail_view_toggler.name = 'Detail_View_Control'
+        detail_view_toggler.set_device_clip_toggle_button(self._note_map[CLIPTRACKVIEW])
+        detail_view_toggler.set_detail_toggle_button(self._note_map[DETAILVIEW])
+        detail_view_toggler.set_device_nav_buttons(self._note_map[DEVICENAVLEFT], self._note_map[DEVICENAVRIGHT])
+
+        transport = SpecialTransportComponent()
+        transport.name = 'Transport'
+        transport.set_play_button(self._note_map[PLAY])
+        transport.set_stop_button(self._note_map[STOP])
+        transport.set_record_button(self._note_map[REC])
+        transport.set_nudge_buttons(self._note_map[NUDGEUP], self._note_map[NUDGEDOWN])
+        transport.set_undo_button(self._note_map[UNDO])
+        transport.set_redo_button(self._note_map[REDO])
+        transport.set_tap_tempo_button(self._note_map[TAPTEMPO])
+        transport.set_quant_toggle_button(self._note_map[RECQUANT])
+        transport.set_overdub_button(self._note_map[OVERDUB])
+        transport.set_metronome_button(self._note_map[METRONOME])
+        transport.set_tempo_control(self._ctrl_map[TEMPOCONTROL])
+        transport.set_loop_button(self._note_map[LOOP])
+        transport.set_seek_buttons(self._note_map[SEEKFWD], self._note_map[SEEKRWD])
+        transport.set_punch_buttons(self._note_map[PUNCHIN], self._note_map[PUNCHOUT])
+        # transport.set_song_position_control(self._ctrl_map[SONGPOSITION]) #still not implemented as of Live 8.1.6
+
+    def _on_selected_track_changed(self):
+        ControlSurface._on_selected_track_changed(self)
+        track = self.song().view.selected_track
+        device_to_select = track.view.selected_device
+        if device_to_select is None and len(track.devices) > 0:
+            device_to_select = track.devices[0]
+        if device_to_select is not None:
+            self.song().view.select_device(device_to_select)
+        self._device_component.set_device(device_to_select)
+
+    def _load_pad_translations(self):
+        if -1 not in DRUM_PADS:
+            pad = []
+            for row in range(4):
+                for col in range(4):
+                    pad = (col, row, DRUM_PADS[row*4 + col], PADCHANNEL,)
+                    self._pads.append(pad)
+            self.set_pad_translations(tuple(self._pads))
+
+    def _load_MIDI_map(self):
+        is_momentary = True
+        for note in range(128):
+            button = ButtonElement(is_momentary, MESSAGETYPE, BUTTONCHANNEL, note)
+            button.name = 'Note_' + str(note)
+            self._note_map.append(button)
+        self._note_map.append(None)     # add None to the end of the list, selectable with [-1]
+        if MESSAGETYPE == MIDI_CC_TYPE and BUTTONCHANNEL == SLIDERCHANNEL:
+            for ctrl in range(128):
+                self._ctrl_map.append(None)
+        else:
+            for ctrl in range(128):
+                control = SliderElement(MIDI_CC_TYPE, SLIDERCHANNEL, ctrl)
+                control.name = 'Ctrl_' + str(ctrl)
+                self._ctrl_map.append(control)
+            self._ctrl_map.append(None)

--- a/live11_users_use_this_folder/YourControllerName/__init__.py
+++ b/live11_users_use_this_folder/YourControllerName/__init__.py
@@ -1,0 +1,11 @@
+
+import Live
+from .YourControllerName import YourControllerName
+
+def create_instance(c_instance):
+    ' Creates and returns the APC20 script '
+    return YourControllerName(c_instance)
+
+
+# local variables:
+# tab-width: 4


### PR DESCRIPTION
- If using Live 11 (sundaynightcoffee updated, PR'd and tested on 11.0.2)
  - Use updated scripts, Ableton 11 uses Python 3 instead of Python 2, which has a few diffs in syntax. 
  - I used python's 2to3 command to update all the scripts in this repo using 2to3 * -w within the YouControllerName directory and deleted all the .bak files. 
  - Follow the same steps as you would for other versions, just be sure to use this 2to3'd version instead.
  - you can also copy the MIDI_map.py between versions, you dont have to rewrite it as these are just variables that python looks at.